### PR TITLE
fix: use react-router match route method

### DIFF
--- a/packages/client/src/ensureReady.js
+++ b/packages/client/src/ensureReady.js
@@ -24,7 +24,7 @@ export async function loadCurrentRoute(
   pathname: string = window.location.pathname
 ) {
   let data;
-  const route = findRouteByPathname(pathname)(routes);
+  const route = findRouteByPathname(pathname, routes);
 
   if (route) {
     const match = matchPath(pathname, route);

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -53,8 +53,9 @@ const checkMatchPath = (pathname: string) => (route: Route) => isNotNil(matchPat
  * Returns a function that will find a route by a given request pathname.
  * @function
  * @param {string} pathname a request pathname
- * @returns {function} (routes[]) => route
+ * @param {Array<Route>} routes a list of routes
+ * @returns {Route} the route matched with the pathname or undefined
  */
-export const findRouteByPathname = curry((pathname: string, routes: Array<Route>) => 
+export const findRouteByPathname = curry((pathname: string, routes: Array<Route>) =>
   find(checkMatchPath(pathname), routes)
 );

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { parse } from 'query-string';
 import { matchPath } from 'react-router-dom';
-import { complement, find, isNil } from 'ramda';
+import { complement, find, isNil, curry } from 'ramda';
 import type { QueryType } from 'Before.component';
 import type { Route } from 'ensureReady';
 
@@ -51,8 +51,10 @@ const checkMatchPath = (pathname: string) => (route: Route) => isNotNil(matchPat
 
 /**
  * Returns a function that will find a route by a given request pathname.
- * @func
+ * @function
  * @param {string} pathname a request pathname
  * @returns {function} (routes[]) => route
  */
-export const findRouteByPathname = (pathname: string) => find(checkMatchPath(pathname));
+export const findRouteByPathname = curry((pathname: string, routes: Array<Route>) => 
+  find(checkMatchPath(pathname), routes)
+);


### PR DESCRIPTION
This solves a bug where the route matching couldn't find the correct route when the
route was using dynamic parameters (ie: /:something/blue).